### PR TITLE
Split universal binary build into separate make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,19 @@ UNIVERSAL_BIN = $(BIN)
 
 .PHONY: all install uninstall clean
 
-all: $(UNIVERSAL_BIN)
+all: $(BIN)
+
+$(BIN):
+	$(CC) -o $(BIN) $(CFLAGS) -framework Foundation -framework ApplicationServices -framework AppKit src/main.m
+
+universal: $(BIN_ARM64) $(BIN_X86_64)
+	lipo -create -output $(BIN) $(BIN_ARM64) $(BIN_X86_64)
 
 $(BIN_ARM64):
 	$(CC) -arch arm64 -o $(BIN_ARM64) $(CFLAGS) -framework Foundation -framework ApplicationServices -framework AppKit src/main.m
 
 $(BIN_X86_64):
 	$(CC) -arch x86_64 -o $(BIN_X86_64) $(CFLAGS) -framework Foundation -framework ApplicationServices -framework AppKit src/main.m
-
-$(UNIVERSAL_BIN): $(BIN_ARM64) $(BIN_X86_64)
-	lipo -create -output $(UNIVERSAL_BIN) $(BIN_ARM64) $(BIN_X86_64)
 
 install: $(BIN)
 	install -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
This pull request modifies the `Makefile` to improve the build process by separating the creation of architecture-specific binaries and the universal binary. The most notable changes simplify the `all` target and introduce explicit rules for building the universal binary.

### Improvements to the build process:

* Simplified the `all` target to build only the main binary (`$(BIN)`), removing the dependency on `$(UNIVERSAL_BIN)`.
* Added a new `universal` target for creating the universal binary by combining architecture-specific binaries (`$(BIN_ARM64)` and `$(BIN_X86_64)`) using the `lipo` command.
* Removed the old `$(UNIVERSAL_BIN)` rule, which previously handled the creation of the universal binary, as it is now replaced by the `universal` target.